### PR TITLE
resolved issue with StyledLink and react-router

### DIFF
--- a/client/src/BooksList/BookItem.jsx
+++ b/client/src/BooksList/BookItem.jsx
@@ -1,5 +1,5 @@
 import { Flex, Text, Button, Link as StyledLink } from "rebass/styled-components";
-import { Link } from "react-router-dom"
+import { Link as RouterLink } from 'react-router-dom'
 import { useMutation, useQueryClient } from "react-query";
 import { removeBook } from "../api";
 import Loader from "react-loader-spinner"
@@ -15,7 +15,7 @@ export const BookItem = ({id, title, author }) => {
 
   return (
     <Flex key={id} p={3} width="100%" alignItems="center">
-      <Link component={StyledLink} to={`/update-book/${id}`} mr="auto">{title}</Link>
+      <StyledLink as={RouterLink} to={`/update-book/${id}`} mr="auto">{title}</StyledLink>
       <Text>{author}</Text>
       <Button onClick={remove} ml="5">
         { isLoading ? <Loader type="ThreeDots" color="#fff" height={10} /> : "Remove" }

--- a/client/src/BooksList/BooksList.jsx
+++ b/client/src/BooksList/BooksList.jsx
@@ -12,7 +12,7 @@ export const BooksList = () => {
     return (
       <Container>
         <Flex py="5" justifyContent="center">
-          <Loader type="ThreeDots" color="#cccccc" height={30} />;
+          <Loader type="ThreeDots" color="#cccccc" height={30} />
         </Flex>
       </Container>
     );

--- a/client/src/UpdateBook/UpdateBook.jsx
+++ b/client/src/UpdateBook/UpdateBook.jsx
@@ -20,7 +20,7 @@ export const UpdateBook = () => {
     return (
       <Container>
         <Flex py="5" justifyContent="center">
-          <Loader type="ThreeDots" color="#cccccc" height={30} />;
+          <Loader type="ThreeDots" color="#cccccc" height={30} />
         </Flex>
       </Container>
     );

--- a/client/src/index.js
+++ b/client/src/index.js
@@ -5,6 +5,7 @@ import "react-loader-spinner/dist/loader/css/react-spinner-loader.css";
 import App from "./App";
 import reportWebVitals from "./reportWebVitals";
 import { QueryClientProvider, QueryClient } from "react-query";
+import { ReactQueryDevtools } from 'react-query/devtools'
 import { BrowserRouter } from "react-router-dom";
 import { ThemeProvider } from "styled-components"
 import preset from '@rebass/preset'
@@ -17,6 +18,7 @@ ReactDOM.render(
       <ThemeProvider theme={preset}>
         <BrowserRouter>
           <App />
+          <ReactQueryDevtools  position="bottom-right" />
         </BrowserRouter>
       </ThemeProvider>
     </QueryClientProvider>

--- a/client/src/shared/NavBar.jsx
+++ b/client/src/shared/NavBar.jsx
@@ -1,11 +1,10 @@
 import {
   Flex,
-  Text,
   Box,
   Link as StyledLink,
   Image,
 } from "rebass/styled-components";
-import { Link } from "react-router-dom";
+import { Link as RouterLink } from 'react-router-dom'
 import { Container } from "./Container"
 import logo from "./logo.svg";
 
@@ -15,13 +14,13 @@ export const NavBar = () => {
       <Container>
         <Flex px={2} width="100%" alignItems="center">
           <Image size={20} src={logo} />
-          <Link component={StyledLink} variant="nav" to="/">
+          <StyledLink as={RouterLink} variant="nav" to="/">
             React Query CRUD
-          </Link>
+          </StyledLink>
           <Box mx="auto" />
-          <Link component={StyledLink} variant="nav" to="/create-book">
+          <StyledLink as={RouterLink} variant="nav" to="/create-book">
             + Add new book
-          </Link>
+            </StyledLink>
         </Flex>
       </Container>
     </Flex>


### PR DESCRIPTION
### Current Issue
There is an issue with StyledLink and react-router-dom that doesn't help demo React-query as well as it should.
When you click on a link that uses  StyledLink, it refreshes the entire page rather than changes the route within the router. This means that react query isn't being utilised as well as it could be.

If you add in the react-query dev tools you will notice that when you change the page, the cache from the previous page gets removed. 

### Fix
I have switched the way the StyledLink component works with Link from react-router-dom (renamed to RouterLink). This now means that when you click on a link it doesn't refresh the page but rather changes the route within the router.
I have also include the react-query dev tools so you can see see that the query caches do get saved between page changes.